### PR TITLE
fix: 全APIルートにtry-catchエラーハンドリングを追加 (#2)

### DIFF
--- a/src/app/api/absences/[id]/recommendations/route.ts
+++ b/src/app/api/absences/[id]/recommendations/route.ts
@@ -5,21 +5,29 @@ import { getRecommendations } from "@/lib/ai/reschedule";
 type RouteContext = { params: Promise<{ id: string }> };
 
 export async function GET(request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const studentId = request.nextUrl.searchParams.get("studentId");
+  try {
+    const { id } = await ctx.params;
+    const studentId = request.nextUrl.searchParams.get("studentId");
 
-  if (!studentId) {
+    if (!studentId) {
+      return NextResponse.json(
+        { error: "生徒IDの指定が必要です" },
+        { status: 400 },
+      );
+    }
+
+    const absence = await getAbsence(id, studentId);
+    if (!absence) {
+      return NextResponse.json({ error: "欠席データが見つかりません" }, { status: 404 });
+    }
+
+    const recommendations = await getRecommendations(absence, studentId);
+    return NextResponse.json(recommendations);
+  } catch (error) {
+    console.error("GET /api/absences/[id]/recommendations error:", error);
     return NextResponse.json(
-      { error: "studentId is required" },
-      { status: 400 },
+      { error: "振替候補の取得に失敗しました" },
+      { status: 500 },
     );
   }
-
-  const absence = await getAbsence(id, studentId);
-  if (!absence) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
-
-  const recommendations = await getRecommendations(absence, studentId);
-  return NextResponse.json(recommendations);
 }

--- a/src/app/api/absences/[id]/route.ts
+++ b/src/app/api/absences/[id]/route.ts
@@ -5,45 +5,75 @@ import type { AbsenceUpdateInput } from "@/lib/types";
 type RouteContext = { params: Promise<{ id: string }> };
 
 export async function GET(_request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const studentId = _request.nextUrl.searchParams.get("studentId");
-  if (!studentId) {
-    return NextResponse.json({ error: "studentId is required" }, { status: 400 });
-  }
+  try {
+    const { id } = await ctx.params;
+    const studentId = _request.nextUrl.searchParams.get("studentId");
+    if (!studentId) {
+      return NextResponse.json({ error: "生徒IDの指定が必要です" }, { status: 400 });
+    }
 
-  const absence = await getAbsence(id, studentId);
-  if (!absence) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const absence = await getAbsence(id, studentId);
+    if (!absence) {
+      return NextResponse.json({ error: "欠席データが見つかりません" }, { status: 404 });
+    }
+    return NextResponse.json(absence);
+  } catch (error) {
+    console.error("GET /api/absences/[id] error:", error);
+    return NextResponse.json(
+      { error: "欠席情報の取得に失敗しました" },
+      { status: 500 },
+    );
   }
-  return NextResponse.json(absence);
 }
 
 export async function PATCH(request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const body = (await request.json()) as AbsenceUpdateInput & { studentId: string };
-  const { studentId, ...updates } = body;
+  try {
+    const { id } = await ctx.params;
+    const body = (await request.json()) as AbsenceUpdateInput & { studentId: string };
+    const { studentId, ...updates } = body;
 
-  if (!studentId) {
-    return NextResponse.json({ error: "studentId is required" }, { status: 400 });
-  }
+    if (!studentId) {
+      return NextResponse.json({ error: "生徒IDの指定が必要です" }, { status: 400 });
+    }
 
-  const absence = await updateAbsence(id, studentId, updates);
-  if (!absence) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const absence = await updateAbsence(id, studentId, updates);
+    if (!absence) {
+      return NextResponse.json({ error: "欠席データが見つかりません" }, { status: 404 });
+    }
+    return NextResponse.json(absence);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: "リクエストの形式が不正です" },
+        { status: 400 },
+      );
+    }
+    console.error("PATCH /api/absences/[id] error:", error);
+    return NextResponse.json(
+      { error: "欠席情報の更新に失敗しました" },
+      { status: 500 },
+    );
   }
-  return NextResponse.json(absence);
 }
 
 export async function DELETE(request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const studentId = request.nextUrl.searchParams.get("studentId");
-  if (!studentId) {
-    return NextResponse.json({ error: "studentId is required" }, { status: 400 });
-  }
+  try {
+    const { id } = await ctx.params;
+    const studentId = request.nextUrl.searchParams.get("studentId");
+    if (!studentId) {
+      return NextResponse.json({ error: "生徒IDの指定が必要です" }, { status: 400 });
+    }
 
-  const success = await deleteAbsence(id, studentId);
-  if (!success) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const success = await deleteAbsence(id, studentId);
+    if (!success) {
+      return NextResponse.json({ error: "欠席データが見つかりません" }, { status: 404 });
+    }
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error("DELETE /api/absences/[id] error:", error);
+    return NextResponse.json(
+      { error: "欠席データの削除に失敗しました" },
+      { status: 500 },
+    );
   }
-  return new NextResponse(null, { status: 204 });
 }

--- a/src/app/api/absences/route.ts
+++ b/src/app/api/absences/route.ts
@@ -3,18 +3,40 @@ import { listAbsences, createAbsence } from "@/lib/absences";
 import type { AbsenceCreateInput } from "@/lib/types";
 
 export async function GET(request: NextRequest) {
-  const { searchParams } = request.nextUrl;
-  const studentId = searchParams.get("studentId") ?? undefined;
-  const status = searchParams.get("status") ?? undefined;
-  const dateFrom = searchParams.get("dateFrom") ?? undefined;
-  const dateTo = searchParams.get("dateTo") ?? undefined;
+  try {
+    const { searchParams } = request.nextUrl;
+    const studentId = searchParams.get("studentId") ?? undefined;
+    const status = searchParams.get("status") ?? undefined;
+    const dateFrom = searchParams.get("dateFrom") ?? undefined;
+    const dateTo = searchParams.get("dateTo") ?? undefined;
 
-  const absences = await listAbsences({ studentId, status, dateFrom, dateTo });
-  return NextResponse.json(absences);
+    const absences = await listAbsences({ studentId, status, dateFrom, dateTo });
+    return NextResponse.json(absences);
+  } catch (error) {
+    console.error("GET /api/absences error:", error);
+    return NextResponse.json(
+      { error: "欠席一覧の取得に失敗しました" },
+      { status: 500 },
+    );
+  }
 }
 
 export async function POST(request: NextRequest) {
-  const body = (await request.json()) as AbsenceCreateInput;
-  const absence = await createAbsence(body);
-  return NextResponse.json(absence, { status: 201 });
+  try {
+    const body = (await request.json()) as AbsenceCreateInput;
+    const absence = await createAbsence(body);
+    return NextResponse.json(absence, { status: 201 });
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: "リクエストの形式が不正です" },
+        { status: 400 },
+      );
+    }
+    console.error("POST /api/absences error:", error);
+    return NextResponse.json(
+      { error: "欠席の登録に失敗しました" },
+      { status: 500 },
+    );
+  }
 }

--- a/src/app/api/billing/[id]/route.ts
+++ b/src/app/api/billing/[id]/route.ts
@@ -5,45 +5,75 @@ import type { BillingUpdateInput } from "@/lib/types";
 type RouteContext = { params: Promise<{ id: string }> };
 
 export async function GET(_request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const studentId = _request.nextUrl.searchParams.get("studentId");
-  if (!studentId) {
-    return NextResponse.json({ error: "studentId is required" }, { status: 400 });
-  }
+  try {
+    const { id } = await ctx.params;
+    const studentId = _request.nextUrl.searchParams.get("studentId");
+    if (!studentId) {
+      return NextResponse.json({ error: "生徒IDの指定が必要です" }, { status: 400 });
+    }
 
-  const record = await getBillingRecord(id, studentId);
-  if (!record) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const record = await getBillingRecord(id, studentId);
+    if (!record) {
+      return NextResponse.json({ error: "請求データが見つかりません" }, { status: 404 });
+    }
+    return NextResponse.json(record);
+  } catch (error) {
+    console.error("GET /api/billing/[id] error:", error);
+    return NextResponse.json(
+      { error: "請求情報の取得に失敗しました" },
+      { status: 500 },
+    );
   }
-  return NextResponse.json(record);
 }
 
 export async function PATCH(request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const body = (await request.json()) as BillingUpdateInput & { studentId: string };
-  const { studentId, ...updates } = body;
+  try {
+    const { id } = await ctx.params;
+    const body = (await request.json()) as BillingUpdateInput & { studentId: string };
+    const { studentId, ...updates } = body;
 
-  if (!studentId) {
-    return NextResponse.json({ error: "studentId is required" }, { status: 400 });
-  }
+    if (!studentId) {
+      return NextResponse.json({ error: "生徒IDの指定が必要です" }, { status: 400 });
+    }
 
-  const record = await updateBillingRecord(id, studentId, updates);
-  if (!record) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const record = await updateBillingRecord(id, studentId, updates);
+    if (!record) {
+      return NextResponse.json({ error: "請求データが見つかりません" }, { status: 404 });
+    }
+    return NextResponse.json(record);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: "リクエストの形式が不正です" },
+        { status: 400 },
+      );
+    }
+    console.error("PATCH /api/billing/[id] error:", error);
+    return NextResponse.json(
+      { error: "請求情報の更新に失敗しました" },
+      { status: 500 },
+    );
   }
-  return NextResponse.json(record);
 }
 
 export async function DELETE(request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const studentId = request.nextUrl.searchParams.get("studentId");
-  if (!studentId) {
-    return NextResponse.json({ error: "studentId is required" }, { status: 400 });
-  }
+  try {
+    const { id } = await ctx.params;
+    const studentId = request.nextUrl.searchParams.get("studentId");
+    if (!studentId) {
+      return NextResponse.json({ error: "生徒IDの指定が必要です" }, { status: 400 });
+    }
 
-  const success = await deleteBillingRecord(id, studentId);
-  if (!success) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const success = await deleteBillingRecord(id, studentId);
+    if (!success) {
+      return NextResponse.json({ error: "請求データが見つかりません" }, { status: 404 });
+    }
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error("DELETE /api/billing/[id] error:", error);
+    return NextResponse.json(
+      { error: "請求データの削除に失敗しました" },
+      { status: 500 },
+    );
   }
-  return new NextResponse(null, { status: 204 });
 }

--- a/src/app/api/billing/route.ts
+++ b/src/app/api/billing/route.ts
@@ -3,17 +3,39 @@ import { listBillingRecords, createBillingRecord } from "@/lib/billing";
 import type { BillingCreateInput } from "@/lib/types";
 
 export async function GET(request: NextRequest) {
-  const { searchParams } = request.nextUrl;
-  const studentId = searchParams.get("studentId") ?? undefined;
-  const status = searchParams.get("status") ?? undefined;
-  const billingMonth = searchParams.get("billingMonth") ?? undefined;
+  try {
+    const { searchParams } = request.nextUrl;
+    const studentId = searchParams.get("studentId") ?? undefined;
+    const status = searchParams.get("status") ?? undefined;
+    const billingMonth = searchParams.get("billingMonth") ?? undefined;
 
-  const records = await listBillingRecords({ studentId, status, billingMonth });
-  return NextResponse.json(records);
+    const records = await listBillingRecords({ studentId, status, billingMonth });
+    return NextResponse.json(records);
+  } catch (error) {
+    console.error("GET /api/billing error:", error);
+    return NextResponse.json(
+      { error: "請求一覧の取得に失敗しました" },
+      { status: 500 },
+    );
+  }
 }
 
 export async function POST(request: NextRequest) {
-  const body = (await request.json()) as BillingCreateInput;
-  const record = await createBillingRecord(body);
-  return NextResponse.json(record, { status: 201 });
+  try {
+    const body = (await request.json()) as BillingCreateInput;
+    const record = await createBillingRecord(body);
+    return NextResponse.json(record, { status: 201 });
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: "リクエストの形式が不正です" },
+        { status: 400 },
+      );
+    }
+    console.error("POST /api/billing error:", error);
+    return NextResponse.json(
+      { error: "請求の登録に失敗しました" },
+      { status: 500 },
+    );
+  }
 }

--- a/src/app/api/grades/[id]/route.ts
+++ b/src/app/api/grades/[id]/route.ts
@@ -5,45 +5,75 @@ import type { ExamResultUpdateInput } from "@/lib/types";
 type RouteContext = { params: Promise<{ id: string }> };
 
 export async function GET(_request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const studentId = _request.nextUrl.searchParams.get("studentId");
-  if (!studentId) {
-    return NextResponse.json({ error: "studentId is required" }, { status: 400 });
-  }
+  try {
+    const { id } = await ctx.params;
+    const studentId = _request.nextUrl.searchParams.get("studentId");
+    if (!studentId) {
+      return NextResponse.json({ error: "生徒IDの指定が必要です" }, { status: 400 });
+    }
 
-  const grade = await getGrade(id, studentId);
-  if (!grade) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const grade = await getGrade(id, studentId);
+    if (!grade) {
+      return NextResponse.json({ error: "成績データが見つかりません" }, { status: 404 });
+    }
+    return NextResponse.json(grade);
+  } catch (error) {
+    console.error("GET /api/grades/[id] error:", error);
+    return NextResponse.json(
+      { error: "成績情報の取得に失敗しました" },
+      { status: 500 },
+    );
   }
-  return NextResponse.json(grade);
 }
 
 export async function PATCH(request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const body = (await request.json()) as ExamResultUpdateInput & { studentId: string };
-  const { studentId, ...updates } = body;
+  try {
+    const { id } = await ctx.params;
+    const body = (await request.json()) as ExamResultUpdateInput & { studentId: string };
+    const { studentId, ...updates } = body;
 
-  if (!studentId) {
-    return NextResponse.json({ error: "studentId is required" }, { status: 400 });
-  }
+    if (!studentId) {
+      return NextResponse.json({ error: "生徒IDの指定が必要です" }, { status: 400 });
+    }
 
-  const grade = await updateGrade(id, studentId, updates);
-  if (!grade) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const grade = await updateGrade(id, studentId, updates);
+    if (!grade) {
+      return NextResponse.json({ error: "成績データが見つかりません" }, { status: 404 });
+    }
+    return NextResponse.json(grade);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: "リクエストの形式が不正です" },
+        { status: 400 },
+      );
+    }
+    console.error("PATCH /api/grades/[id] error:", error);
+    return NextResponse.json(
+      { error: "成績情報の更新に失敗しました" },
+      { status: 500 },
+    );
   }
-  return NextResponse.json(grade);
 }
 
 export async function DELETE(request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const studentId = request.nextUrl.searchParams.get("studentId");
-  if (!studentId) {
-    return NextResponse.json({ error: "studentId is required" }, { status: 400 });
-  }
+  try {
+    const { id } = await ctx.params;
+    const studentId = request.nextUrl.searchParams.get("studentId");
+    if (!studentId) {
+      return NextResponse.json({ error: "生徒IDの指定が必要です" }, { status: 400 });
+    }
 
-  const success = await deleteGrade(id, studentId);
-  if (!success) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const success = await deleteGrade(id, studentId);
+    if (!success) {
+      return NextResponse.json({ error: "成績データが見つかりません" }, { status: 404 });
+    }
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error("DELETE /api/grades/[id] error:", error);
+    return NextResponse.json(
+      { error: "成績データの削除に失敗しました" },
+      { status: 500 },
+    );
   }
-  return new NextResponse(null, { status: 204 });
 }

--- a/src/app/api/grades/route.ts
+++ b/src/app/api/grades/route.ts
@@ -3,17 +3,39 @@ import { listGrades, createGrade } from "@/lib/grades";
 import type { ExamResultCreateInput } from "@/lib/types";
 
 export async function GET(request: NextRequest) {
-  const { searchParams } = request.nextUrl;
-  const studentId = searchParams.get("studentId") ?? undefined;
-  const examType = searchParams.get("examType") ?? undefined;
-  const subject = searchParams.get("subject") ?? undefined;
+  try {
+    const { searchParams } = request.nextUrl;
+    const studentId = searchParams.get("studentId") ?? undefined;
+    const examType = searchParams.get("examType") ?? undefined;
+    const subject = searchParams.get("subject") ?? undefined;
 
-  const grades = await listGrades({ studentId, examType, subject });
-  return NextResponse.json(grades);
+    const grades = await listGrades({ studentId, examType, subject });
+    return NextResponse.json(grades);
+  } catch (error) {
+    console.error("GET /api/grades error:", error);
+    return NextResponse.json(
+      { error: "成績一覧の取得に失敗しました" },
+      { status: 500 },
+    );
+  }
 }
 
 export async function POST(request: NextRequest) {
-  const body = (await request.json()) as ExamResultCreateInput;
-  const grade = await createGrade(body);
-  return NextResponse.json(grade, { status: 201 });
+  try {
+    const body = (await request.json()) as ExamResultCreateInput;
+    const grade = await createGrade(body);
+    return NextResponse.json(grade, { status: 201 });
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: "リクエストの形式が不正です" },
+        { status: 400 },
+      );
+    }
+    console.error("POST /api/grades error:", error);
+    return NextResponse.json(
+      { error: "成績の登録に失敗しました" },
+      { status: 500 },
+    );
+  }
 }

--- a/src/app/api/schedules/[id]/route.ts
+++ b/src/app/api/schedules/[id]/route.ts
@@ -5,45 +5,75 @@ import type { ScheduleUpdateInput } from "@/lib/types";
 type RouteContext = { params: Promise<{ id: string }> };
 
 export async function GET(_request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const dayOfWeekParam = _request.nextUrl.searchParams.get("dayOfWeek");
-  if (dayOfWeekParam === null) {
-    return NextResponse.json({ error: "dayOfWeek is required" }, { status: 400 });
-  }
+  try {
+    const { id } = await ctx.params;
+    const dayOfWeekParam = _request.nextUrl.searchParams.get("dayOfWeek");
+    if (dayOfWeekParam === null) {
+      return NextResponse.json({ error: "曜日の指定が必要です" }, { status: 400 });
+    }
 
-  const schedule = await getSchedule(id, Number(dayOfWeekParam));
-  if (!schedule) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const schedule = await getSchedule(id, Number(dayOfWeekParam));
+    if (!schedule) {
+      return NextResponse.json({ error: "スケジュールが見つかりません" }, { status: 404 });
+    }
+    return NextResponse.json(schedule);
+  } catch (error) {
+    console.error("GET /api/schedules/[id] error:", error);
+    return NextResponse.json(
+      { error: "スケジュールの取得に失敗しました" },
+      { status: 500 },
+    );
   }
-  return NextResponse.json(schedule);
 }
 
 export async function PATCH(request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const body = (await request.json()) as ScheduleUpdateInput & { dayOfWeek: number };
-  const { dayOfWeek, ...updates } = body;
+  try {
+    const { id } = await ctx.params;
+    const body = (await request.json()) as ScheduleUpdateInput & { dayOfWeek: number };
+    const { dayOfWeek, ...updates } = body;
 
-  if (dayOfWeek === undefined) {
-    return NextResponse.json({ error: "dayOfWeek is required" }, { status: 400 });
-  }
+    if (dayOfWeek === undefined) {
+      return NextResponse.json({ error: "曜日の指定が必要です" }, { status: 400 });
+    }
 
-  const schedule = await updateSchedule(id, dayOfWeek, updates);
-  if (!schedule) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const schedule = await updateSchedule(id, dayOfWeek, updates);
+    if (!schedule) {
+      return NextResponse.json({ error: "スケジュールが見つかりません" }, { status: 404 });
+    }
+    return NextResponse.json(schedule);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: "リクエストの形式が不正です" },
+        { status: 400 },
+      );
+    }
+    console.error("PATCH /api/schedules/[id] error:", error);
+    return NextResponse.json(
+      { error: "スケジュールの更新に失敗しました" },
+      { status: 500 },
+    );
   }
-  return NextResponse.json(schedule);
 }
 
 export async function DELETE(request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const dayOfWeekParam = request.nextUrl.searchParams.get("dayOfWeek");
-  if (dayOfWeekParam === null) {
-    return NextResponse.json({ error: "dayOfWeek is required" }, { status: 400 });
-  }
+  try {
+    const { id } = await ctx.params;
+    const dayOfWeekParam = request.nextUrl.searchParams.get("dayOfWeek");
+    if (dayOfWeekParam === null) {
+      return NextResponse.json({ error: "曜日の指定が必要です" }, { status: 400 });
+    }
 
-  const success = await deleteSchedule(id, Number(dayOfWeekParam));
-  if (!success) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const success = await deleteSchedule(id, Number(dayOfWeekParam));
+    if (!success) {
+      return NextResponse.json({ error: "スケジュールが見つかりません" }, { status: 404 });
+    }
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error("DELETE /api/schedules/[id] error:", error);
+    return NextResponse.json(
+      { error: "スケジュールの削除に失敗しました" },
+      { status: 500 },
+    );
   }
-  return new NextResponse(null, { status: 204 });
 }

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -3,18 +3,40 @@ import { listSchedules, createSchedule } from "@/lib/schedules";
 import type { ScheduleCreateInput } from "@/lib/types";
 
 export async function GET(request: NextRequest) {
-  const { searchParams } = request.nextUrl;
-  const dayOfWeekParam = searchParams.get("dayOfWeek");
-  const subject = searchParams.get("subject") ?? undefined;
+  try {
+    const { searchParams } = request.nextUrl;
+    const dayOfWeekParam = searchParams.get("dayOfWeek");
+    const subject = searchParams.get("subject") ?? undefined;
 
-  const dayOfWeek = dayOfWeekParam !== null ? Number(dayOfWeekParam) : undefined;
+    const dayOfWeek = dayOfWeekParam !== null ? Number(dayOfWeekParam) : undefined;
 
-  const schedules = await listSchedules({ dayOfWeek, subject });
-  return NextResponse.json(schedules);
+    const schedules = await listSchedules({ dayOfWeek, subject });
+    return NextResponse.json(schedules);
+  } catch (error) {
+    console.error("GET /api/schedules error:", error);
+    return NextResponse.json(
+      { error: "スケジュール一覧の取得に失敗しました" },
+      { status: 500 },
+    );
+  }
 }
 
 export async function POST(request: NextRequest) {
-  const body = (await request.json()) as ScheduleCreateInput;
-  const schedule = await createSchedule(body);
-  return NextResponse.json(schedule, { status: 201 });
+  try {
+    const body = (await request.json()) as ScheduleCreateInput;
+    const schedule = await createSchedule(body);
+    return NextResponse.json(schedule, { status: 201 });
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: "リクエストの形式が不正です" },
+        { status: 400 },
+      );
+    }
+    console.error("POST /api/schedules error:", error);
+    return NextResponse.json(
+      { error: "スケジュールの登録に失敗しました" },
+      { status: 500 },
+    );
+  }
 }

--- a/src/app/api/students/[id]/route.ts
+++ b/src/app/api/students/[id]/route.ts
@@ -5,45 +5,75 @@ import type { StudentUpdateInput } from "@/lib/types";
 type RouteContext = { params: Promise<{ id: string }> };
 
 export async function GET(_request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const gradeLevel = _request.nextUrl.searchParams.get("gradeLevel");
-  if (!gradeLevel) {
-    return NextResponse.json({ error: "gradeLevel is required" }, { status: 400 });
-  }
+  try {
+    const { id } = await ctx.params;
+    const gradeLevel = _request.nextUrl.searchParams.get("gradeLevel");
+    if (!gradeLevel) {
+      return NextResponse.json({ error: "学年の指定が必要です" }, { status: 400 });
+    }
 
-  const student = await getStudent(id, gradeLevel);
-  if (!student) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const student = await getStudent(id, gradeLevel);
+    if (!student) {
+      return NextResponse.json({ error: "生徒が見つかりません" }, { status: 404 });
+    }
+    return NextResponse.json(student);
+  } catch (error) {
+    console.error("GET /api/students/[id] error:", error);
+    return NextResponse.json(
+      { error: "生徒情報の取得に失敗しました" },
+      { status: 500 },
+    );
   }
-  return NextResponse.json(student);
 }
 
 export async function PATCH(request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const body = (await request.json()) as StudentUpdateInput & { gradeLevel: string };
-  const { gradeLevel, ...updates } = body;
+  try {
+    const { id } = await ctx.params;
+    const body = (await request.json()) as StudentUpdateInput & { gradeLevel: string };
+    const { gradeLevel, ...updates } = body;
 
-  if (!gradeLevel) {
-    return NextResponse.json({ error: "gradeLevel is required" }, { status: 400 });
-  }
+    if (!gradeLevel) {
+      return NextResponse.json({ error: "学年の指定が必要です" }, { status: 400 });
+    }
 
-  const student = await updateStudent(id, gradeLevel, updates);
-  if (!student) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const student = await updateStudent(id, gradeLevel, updates);
+    if (!student) {
+      return NextResponse.json({ error: "生徒が見つかりません" }, { status: 404 });
+    }
+    return NextResponse.json(student);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: "リクエストの形式が不正です" },
+        { status: 400 },
+      );
+    }
+    console.error("PATCH /api/students/[id] error:", error);
+    return NextResponse.json(
+      { error: "生徒情報の更新に失敗しました" },
+      { status: 500 },
+    );
   }
-  return NextResponse.json(student);
 }
 
 export async function DELETE(request: NextRequest, ctx: RouteContext) {
-  const { id } = await ctx.params;
-  const gradeLevel = request.nextUrl.searchParams.get("gradeLevel");
-  if (!gradeLevel) {
-    return NextResponse.json({ error: "gradeLevel is required" }, { status: 400 });
-  }
+  try {
+    const { id } = await ctx.params;
+    const gradeLevel = request.nextUrl.searchParams.get("gradeLevel");
+    if (!gradeLevel) {
+      return NextResponse.json({ error: "学年の指定が必要です" }, { status: 400 });
+    }
 
-  const success = await deleteStudent(id, gradeLevel);
-  if (!success) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const success = await deleteStudent(id, gradeLevel);
+    if (!success) {
+      return NextResponse.json({ error: "生徒が見つかりません" }, { status: 404 });
+    }
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error("DELETE /api/students/[id] error:", error);
+    return NextResponse.json(
+      { error: "生徒の削除に失敗しました" },
+      { status: 500 },
+    );
   }
-  return new NextResponse(null, { status: 204 });
 }

--- a/src/app/api/students/route.ts
+++ b/src/app/api/students/route.ts
@@ -3,16 +3,38 @@ import { listStudents, createStudent } from "@/lib/students";
 import type { StudentCreateInput } from "@/lib/types";
 
 export async function GET(request: NextRequest) {
-  const { searchParams } = request.nextUrl;
-  const gradeLevel = searchParams.get("gradeLevel") ?? undefined;
-  const enrollmentStatus = searchParams.get("enrollmentStatus") ?? undefined;
+  try {
+    const { searchParams } = request.nextUrl;
+    const gradeLevel = searchParams.get("gradeLevel") ?? undefined;
+    const enrollmentStatus = searchParams.get("enrollmentStatus") ?? undefined;
 
-  const students = await listStudents({ gradeLevel, enrollmentStatus });
-  return NextResponse.json(students);
+    const students = await listStudents({ gradeLevel, enrollmentStatus });
+    return NextResponse.json(students);
+  } catch (error) {
+    console.error("GET /api/students error:", error);
+    return NextResponse.json(
+      { error: "生徒一覧の取得に失敗しました" },
+      { status: 500 },
+    );
+  }
 }
 
 export async function POST(request: NextRequest) {
-  const body = (await request.json()) as StudentCreateInput;
-  const student = await createStudent(body);
-  return NextResponse.json(student, { status: 201 });
+  try {
+    const body = (await request.json()) as StudentCreateInput;
+    const student = await createStudent(body);
+    return NextResponse.json(student, { status: 201 });
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: "リクエストの形式が不正です" },
+        { status: 400 },
+      );
+    }
+    console.error("POST /api/students error:", error);
+    return NextResponse.json(
+      { error: "生徒の登録に失敗しました" },
+      { status: 500 },
+    );
+  }
 }


### PR DESCRIPTION
## 関連Issue

Closes #2

## 変更内容

全APIルート（11ファイル）にtry-catchエラーハンドリングを追加。未処理例外によるスタックトレースのクライアント露出を防止する。あわせてエラーメッセージを日本語に統一（#4 の部分対応）。

## 主な変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/app/api/students/route.ts` | GET/POST に try-catch 追加 |
| `src/app/api/students/[id]/route.ts` | GET/PATCH/DELETE に try-catch 追加、エラーメッセージ日本語化 |
| `src/app/api/grades/route.ts` | GET/POST に try-catch 追加 |
| `src/app/api/grades/[id]/route.ts` | GET/PATCH/DELETE に try-catch 追加、エラーメッセージ日本語化 |
| `src/app/api/billing/route.ts` | GET/POST に try-catch 追加 |
| `src/app/api/billing/[id]/route.ts` | GET/PATCH/DELETE に try-catch 追加、エラーメッセージ日本語化 |
| `src/app/api/absences/route.ts` | GET/POST に try-catch 追加 |
| `src/app/api/absences/[id]/route.ts` | GET/PATCH/DELETE に try-catch 追加、エラーメッセージ日本語化 |
| `src/app/api/absences/[id]/recommendations/route.ts` | GET に try-catch 追加、エラーメッセージ日本語化 |
| `src/app/api/schedules/route.ts` | GET/POST に try-catch 追加 |
| `src/app/api/schedules/[id]/route.ts` | GET/PATCH/DELETE に try-catch 追加、エラーメッセージ日本語化 |

## エラーハンドリング方針

- `SyntaxError`（JSON パース失敗）→ **400 Bad Request**
- DB障害・予期せぬエラー → **500 Internal Server Error**
- エラーレスポンスに内部情報（スタックトレース等）を含めない
- `console.error` でサーバーログに詳細を記録

## 確認項目

- [x] `npm run lint` パス（0 errors, 既存の 8 warnings のみ）
- [x] `npm run build` パス
- [x] 既存機能への影響なし（ハンドラのロジック変更なし）
- [x] 新しい環境変数の追加なし

## レビュー観点

- try-catch の粒度が適切か（ハンドラ単位で wrap）
- エラーメッセージの日本語表現が適切か
- `settings/tuition/route.ts` は既に対応済みのため変更なし